### PR TITLE
cleanup redundant log when pushing branch

### DIFF
--- a/internal/web/git/pulls.go
+++ b/internal/web/git/pulls.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fatih/color"
 	"github.com/google/go-github/v32/github"
 	"github.com/kathleenfrench/pls/internal/config"
 	"github.com/kathleenfrench/pls/pkg/gui"
@@ -215,8 +214,6 @@ func CreatePullRequestFromCWD(settings config.Settings) error {
 
 // undocumented, but: mergeable state values: clean, dirty, blocked, unstable, or unknown
 func pollForMergeability(gc *github.Client, pr *github.PullRequest, meta *IssueMeta) bool {
-	color.HiYellow("initial check - mergeable: %v, state: %v", pr.GetMergeable(), pr.GetMergeableState())
-
 	if pr.GetMergeable() {
 		return true
 	}
@@ -233,8 +230,6 @@ func pollForMergeability(gc *github.Client, pr *github.PullRequest, meta *IssueM
 			if err != nil {
 				return false
 			}
-
-			color.HiYellow("pr check - mergeable: %v, state: %v", prCheck.GetMergeable(), prCheck.GetMergeableState())
 
 			if prCheck.GetMergeable() {
 				break

--- a/internal/web/git/pulls_ui.go
+++ b/internal/web/git/pulls_ui.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fatih/color"
 	"github.com/google/go-github/v32/github"
 	"github.com/kathleenfrench/pls/internal/config"
 	"github.com/kathleenfrench/pls/pkg/gui"
@@ -57,8 +56,7 @@ func ChooseWhatToDoWithIssue(gc *github.Client, issue *github.Issue, meta *Issue
 		state   string
 	)
 
-	// TODO: REMOVE mergeableStateTest
-	opts := []string{openInBrowser, readBodyText, editSelection, mergeableStateTest}
+	opts := []string{openInBrowser, readBodyText, editSelection}
 	ctx := context.Background()
 
 	isPullRequest := issue.IsPullRequest()
@@ -157,16 +155,13 @@ func ChooseWhatToDoWithIssue(gc *github.Client, issue *github.Issue, meta *Issue
 			gui.Log(":+1:", fmt.Sprintf("successfully updated your issue %q", updatedIssue.GetTitle()), updatedIssue.GetNumber())
 			issue = updatedIssue
 		}
-	case mergeableStateTest:
+	case mergeSelection:
 		mergeable := pollForMergeability(gc, pr, meta)
 		if mergeable {
-			color.HiBlue("mergeable!")
+			gui.Log(":+1:", fmt.Sprintf("%q is mergeable!", pr.GetTitle()), nil)
 		} else {
-			color.HiRed("not mergeable!")
-		}
-	case mergeSelection:
-		if !pr.GetMergeable() || pr.GetMergeableState() != "clean" {
-			return fmt.Errorf("this PR is currently not in a mergeable state - mergeable: %v, mergeable state: %v", pr.GetMergeable(), pr.GetMergeableState())
+			noMergeErr := fmt.Sprintf("%q is not mergeable - current state: %s", pr.GetTitle(), pr.GetMergeableState())
+			return errors.New(noMergeErr)
 		}
 
 		methods := []string{mergeStraight, mergeSquash, mergeRebase}

--- a/internal/web/git/selections.go
+++ b/internal/web/git/selections.go
@@ -43,6 +43,4 @@ const (
 	mergeSquash   = "squash"
 	mergeRebase   = "rebase"
 	mergeStraight = "merge"
-
-	mergeableStateTest = "merge test"
 )


### PR DESCRIPTION
removes a redundant log from the remote ref check flow for a branch -> PR pipeline


---
<sub>:balloon: i opened this PR by saying [`pls`](https://github.com/kathleenfrench/pls)</sub>
