### PR TITLE
add list as an alias on show

### DIFF
--- a/cmd/pls/show.go
+++ b/cmd/pls/show.go
@@ -12,7 +12,7 @@ import (
 var showCmd = &cobra.Command{
 	Use:     "show",
 	Short:   "show values for various resources",
-	Aliases: []string{"s", "print", "list"},
+	Aliases: []string{"s", "print", "list", "l"},
 }
 
 var showConfigsCmd = &cobra.Command{


### PR DESCRIPTION
adds `list` as an alias on `show` subcommand


---
<sub>:balloon: i opened this PR by saying [`pls`](https://github.com/kathleenfrench/pls)</sub>
