### PR TITLE
fix broken jekyll gh-page links

### DIFF
--- a/cmd/pls/make.go
+++ b/cmd/pls/make.go
@@ -49,7 +49,7 @@ var makeDocsCmd = &cobra.Command{
 		fp := internalutils.FrontMatter
 		linkHandler := func(name string) string {
 			base := strings.TrimSuffix(name, path.Ext(name))
-			return fmt.Sprintf("/%s/", strings.ToLower(base))
+			return fmt.Sprintf("/pls/%s/", strings.ToLower(base))
 		}
 
 		err = internalutils.GenMarkdownDocumentation(cmd.Root(), fmt.Sprintf("./%s", internalutils.PublishDocsDirectory), fp, linkHandler)

--- a/internal/utils/docs.go
+++ b/internal/utils/docs.go
@@ -29,7 +29,7 @@ layout: default
 
 	name := filepath.Base(filename)
 	base := strings.TrimSuffix(name, path.Ext(name))
-	url := "/" + strings.ToLower(base) + "/"
+	url := "/pls/" + strings.ToLower(base) + "/"
 	front := fmt.Sprintf(fmTemplate, strings.Replace(base, "_", " ", -1), base, url, summary)
 	return front
 }


### PR DESCRIPTION
needed to change the link handlers to include `/pls` 


---
<sub>:balloon: i opened this PR by saying [`pls`](https://github.com/kathleenfrench/pls)</sub>
