### PR TITLE
exclude docs and readme from git actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,10 @@
 name: pls
-on: push
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'LICENSE'
 env:
   GO111MODULE: on
 jobs:


### PR DESCRIPTION
add `paths-ignore` property to the workflow so as to not require various tests to be run when it's not applicable


---
<sub>:balloon: i opened this PR by saying [`pls`](https://github.com/kathleenfrench/pls)</sub>
