### PR TITLE
add support for nvim as an editor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ endif
 endif
 
 GOOS = $(PLATFORM)
-GOARCH ?= arm64
+GOARCH := amd64
+# GOARCH ?= arm64
 
 GO := $(shell command -v go 2>/dev/null)
 GO_LINKER_FLAGS = -X $(CMD_MODULE).Builder=$(WHOAMI) -X $(CMD_MODULE).Version=$(VERSION) -X $(CMD_MODULE).Commit=$(COMMIT) -X $(CMD_MODULE).Date=$(TODAY)
@@ -59,7 +60,7 @@ lint: ## go linter and shadow tool
 	@$(GO) vet -vettool=$(shell which shadow) ./...
 
 .PHONY: test
-test: lint ## run linter and unit tests 
+test: lint ## run linter and unit tests
 	@echo "running tests..."
 	@$(GO) test ./...
 

--- a/internal/config/gui.go
+++ b/internal/config/gui.go
@@ -45,7 +45,7 @@ func genGuiKeyMap(keys []string) ([]string, map[string]string) {
 }
 
 func promptForDefaultEditor() string {
-	options := []string{"vim", "emacs", "vscode", "atom", "sublime", "phpstorm"}
+	options := []string{"vim", "nvim", "emacs", "vscode", "atom", "sublime", "phpstorm"}
 	selection := gui.SelectPromptWithResponse("which would you like to set as your default editor?", options, "vim", false)
 
 	switch selection {

--- a/pkg/utils/exec.go
+++ b/pkg/utils/exec.go
@@ -82,6 +82,7 @@ func OpenURLInDefaultBrowser(url string) error {
 // EditorLaunchCommands are the commands used to open a file in a specified text editor and wait for the file to be saved to close
 var EditorLaunchCommands = map[string]string{
 	"vim":      "vim",
+	"nvim": 		"nvim",
 	"emacs":    "emacs",
 	"vscode":   "code --wait",
 	"atom":     "atom --wait",


### PR DESCRIPTION
this adds `nvim` as a supported editor when launching tmp editor buffers for use in `pls` prompts


---
<sub>:balloon: i opened this PR by saying [`pls`](https://github.com/kathleenfrench/pls)</sub>
